### PR TITLE
Fixes for pipeline #43

### DIFF
--- a/.github/workflows/azure-analyze.yaml
+++ b/.github/workflows/azure-analyze.yaml
@@ -30,10 +30,30 @@ jobs:
     if: github.repository != 'Azure/PSRule.Rules.Azure-quickstart'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Run analysis by using the PSRule GitHub action.
       - name: Run PSRule analysis
         uses: microsoft/ps-rule@v2.9.0
         with:
           modules: PSRule.Rules.Azure
+          outputFormat: Sarif
+          outputPath: reports/ps-rule-results.sarif
+          summary: true
+
+      # If you have GitHub Advanced Security you can upload PSRule scan results.
+      # Uncomment the next step to use this feature.
+      # - name: Upload results to security tab
+      #   uses: github/codeql-action/upload-sarif@v2
+      #   if: always()
+      #   with:
+      #     sarif_file: reports/ps-rule-results.sarif
+
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: PSRule-Sarif
+          path: reports/ps-rule-results.sarif
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/ms-analyze.yaml
+++ b/.github/workflows/ms-analyze.yaml
@@ -28,7 +28,7 @@ jobs:
     if: github.repository == 'Azure/PSRule.Rules.Azure-quickstart'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run PSRule analysis
         uses: microsoft/ps-rule@v2.9.0

--- a/.pipelines/azure-analyze-with-monitor.yaml
+++ b/.pipelines/azure-analyze-with-monitor.yaml
@@ -55,3 +55,4 @@ stages:
     - publish: $(System.DefaultWorkingDirectory)/reports/ps-rule-results.sarif
       artifact: CodeAnalysisLogs
       displayName: Publish SARIF logs
+      condition: succeededOrFailed()

--- a/.pipelines/azure-analyze.yaml
+++ b/.pipelines/azure-analyze.yaml
@@ -41,3 +41,4 @@ stages:
     - publish: $(System.DefaultWorkingDirectory)/reports/ps-rule-results.sarif
       artifact: CodeAnalysisLogs
       displayName: Publish SARIF logs
+      condition: succeededOrFailed()

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -13,10 +13,13 @@ binding:
     - type
     - resourceType
 
+execution:
+  unprocessedObject: Ignore
+
 # Require minimum versions of modules.
 requires:
   PSRule: '@pre >=2.9.0'
-  PSRule.Rules.Azure: '@pre >=1.28.2'
+  PSRule.Rules.Azure: '@pre >=1.31.1'
 
 # Use PSRule for Azure.
 include:


### PR DESCRIPTION
## PR Summary

- Updates to ADO pipeline code to properly upload scan results when there is failures.
- Disable unprocessed warning in `ps-rule.yaml`.
- Bumped GitHub Actions pipelines.
- Added SARIF upload to artifacts and GitHub Advanced security as on option.

Related to #43 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
